### PR TITLE
Add schema extensions for transcriptomic benchmarking of derivation protocols

### DIFF
--- a/src/namo/schema/namo.yaml
+++ b/src/namo/schema/namo.yaml
@@ -178,6 +178,7 @@ imports:
 classes:
 
   Dataset:
+    is_a: NamedThing
     attributes:
       model_systems:
         range: ModelSystem
@@ -722,6 +723,7 @@ classes:
           Known variants or modifications of this protocol
 
   ProtocolStep:
+    is_a: NamedThing
     description: >-
       An individual step within a derivation protocol with specific conditions and timing.
     attributes:
@@ -753,6 +755,7 @@ classes:
           Critical parameters that must be controlled in this step
 
   ProtocolReagent:
+    is_a: NamedThing
     description: >-
       A reagent used in a protocol step with specific concentration and role.
     attributes:
@@ -772,6 +775,7 @@ classes:
           Commercial supplier and catalog number if applicable
 
   ProtocolReproducibility:
+    is_a: NamedThing
     description: >-
       Assessment of protocol reproducibility and robustness across different conditions.
     attributes:
@@ -886,6 +890,7 @@ classes:
           Quality assessment metrics for the database
 
   ComparisonMethodology:
+    is_a: NamedThing
     description: >-
       Methodology used for comparing multiple derivation protocols in a benchmarking study.
     attributes:
@@ -911,6 +916,7 @@ classes:
           Clustering or dimensionality reduction methods used
 
   BenchmarkingMetric:
+    is_a: NamedThing
     description: >-
       Specific metric used to assess the performance of derivation protocols.
     attributes:
@@ -941,12 +947,12 @@ classes:
           What this metric is being compared against
 
   ProtocolRanking:
+    is_a: NamedThing
     description: >-
       Ranking of a protocol based on benchmarking results.
     attributes:
       protocol:
         range: DerivationProtocol
-        inlined: true
         required: true
         description: >-
           The protocol being ranked
@@ -1000,6 +1006,7 @@ classes:
           Weight of this category in overall scoring
 
   DataQualityMetric:
+    is_a: NamedThing
     description: >-
       Quality assessment metric for external databases used in benchmarking.
     attributes:

--- a/src/namo/schema/namo.yaml
+++ b/src/namo/schema/namo.yaml
@@ -658,6 +658,369 @@ classes:
       Examples: Virtual Physiological Human, ...
 
   # ==========================================
+  # DERIVATION PROTOCOLS AND BENCHMARKING
+  # ==========================================
+
+  DerivationProtocol:
+    is_a: NamedThing
+    description: >-
+      A standardized procedure for differentiating or deriving specific cell types
+      from precursor cells (e.g., deriving macrophages from monocytes, neurons from iPSCs).
+      Includes detailed methodology, reagents, timing, and conditions.
+    attributes:
+      starting_cell_type:
+        range: Term
+        inlined: true
+        required: true
+        description: >-
+          The initial cell type or source for differentiation
+        bindings:
+          - binds_value_of: id
+            range: CellTypeEnum
+            obligation_level: REQUIRED
+      target_cell_type:
+        range: Term
+        inlined: true
+        required: true
+        description: >-
+          The intended final differentiated cell type
+        bindings:
+          - binds_value_of: id
+            range: CellTypeEnum
+            obligation_level: REQUIRED
+      protocol_steps:
+        range: ProtocolStep
+        multivalued: true
+        inlined_as_list: true
+        description: >-
+          Ordered list of protocol steps with timing and reagents
+      duration_days:
+        range: float
+        description: >-
+          Total protocol duration in days
+      success_criteria:
+        multivalued: true
+        description: >-
+          Criteria used to assess successful differentiation (markers, morphology, function)
+      efficiency_percentage:
+        range: float
+        description: >-
+          Typical efficiency of differentiation (0-100%)
+      reproducibility_assessment:
+        range: ProtocolReproducibility
+        inlined: true
+        description: >-
+          Assessment of protocol reproducibility across conditions
+      original_publication:
+        range: Reference
+        inlined: true
+        description: >-
+          Original publication describing this protocol
+      protocol_variants:
+        multivalued: true
+        description: >-
+          Known variants or modifications of this protocol
+
+  ProtocolStep:
+    description: >-
+      An individual step within a derivation protocol with specific conditions and timing.
+    attributes:
+      step_number:
+        range: integer
+        required: true
+        description: >-
+          Order of this step in the protocol (1, 2, 3, etc.)
+      step_name:
+        required: true
+        description: >-
+          Brief name describing this protocol step
+      duration_hours:
+        range: float
+        description: >-
+          Duration of this step in hours
+      reagents:
+        range: ProtocolReagent
+        multivalued: true
+        inlined_as_list: true
+        description: >-
+          Reagents and their concentrations used in this step
+      culture_conditions:
+        description: >-
+          Specific culture conditions for this step (temperature, CO2, etc.)
+      critical_parameters:
+        multivalued: true
+        description: >-
+          Critical parameters that must be controlled in this step
+
+  ProtocolReagent:
+    description: >-
+      A reagent used in a protocol step with specific concentration and role.
+    attributes:
+      reagent_name:
+        required: true
+        description: >-
+          Name of the reagent (e.g., "IL-4", "M-CSF", "Retinoic acid")
+      concentration:
+        description: >-
+          Concentration of the reagent (include units)
+      reagent_role:
+        range: ReagentRoleEnum
+        description: >-
+          Role of the reagent in differentiation
+      supplier:
+        description: >-
+          Commercial supplier and catalog number if applicable
+
+  ProtocolReproducibility:
+    description: >-
+      Assessment of protocol reproducibility and robustness across different conditions.
+    attributes:
+      inter_laboratory_variability:
+        range: float
+        description: >-
+          Coefficient of variation across different laboratories (0-1)
+      batch_to_batch_consistency:
+        range: float
+        description: >-
+          Consistency score across different reagent batches (0-1)
+      operator_dependence:
+        range: OperatorDependenceEnum
+        description: >-
+          Level of dependence on operator skill and experience
+      equipment_sensitivity:
+        range: EquipmentSensitivityEnum
+        description: >-
+          Sensitivity to specific equipment or instrumentation
+      cost_assessment:
+        range: CostLevelEnum
+        description: >-
+          Relative cost level of the protocol
+      time_investment:
+        range: TimeInvestmentEnum
+        description: >-
+          Required time investment level
+
+  ProtocolBenchmarkingStudy:
+    is_a: Study
+    description: >-
+      A study that systematically compares multiple derivation protocols using
+      transcriptomic or other molecular analysis to assess their relative performance
+      and physiological relevance. Exemplified by studies comparing macrophage 
+      polarization methods using RNA-seq.
+    attributes:
+      protocols_compared:
+        range: DerivationProtocol
+        multivalued: true
+        inlined_as_list: true
+        required: true
+        description: >-
+          List of derivation protocols being compared in this study
+      reference_datasets:
+        range: ExternalDatabase
+        multivalued: true
+        inlined_as_list: true
+        description: >-
+          External databases or datasets used for comparison (e.g., primary tissue RNA-seq)
+      comparison_methodology:
+        range: ComparisonMethodology
+        inlined: true
+        description: >-
+          Methodology used for comparing protocols
+      benchmarking_metrics:
+        range: BenchmarkingMetric
+        multivalued: true
+        inlined_as_list: true
+        description: >-
+          Specific metrics used to assess protocol performance
+      protocol_ranking:
+        range: ProtocolRanking
+        multivalued: true
+        inlined_as_list: true
+        description: >-
+          Ranking of protocols based on benchmarking results
+
+  ExternalDatabase:
+    is_a: NamedThing
+    description: >-
+      External database or dataset used as reference for protocol benchmarking,
+      such as primary tissue gene expression databases or other reference datasets.
+    attributes:
+      database_type:
+        range: DatabaseTypeEnum
+        description: >-
+          Type of database (e.g., gene expression, proteomics, single-cell)
+      data_source:
+        description: >-
+          Source of the data (e.g., primary tissues, clinical samples, literature)
+      sample_size:
+        range: integer
+        description: >-
+          Number of samples in the database
+      species:
+        range: Term
+        inlined: true
+        description: >-
+          Species of samples in database
+        bindings:
+          - binds_value_of: id
+            range: SpeciesEnum
+            obligation_level: REQUIRED
+      tissue_types:
+        range: Term
+        multivalued: true
+        inlined_as_list: true
+        description: >-
+          Tissue types represented in the database
+      access_url:
+        range: uri
+        description: >-
+          URL to access the database
+      data_processing:
+        description: >-
+          Description of data processing and normalization methods
+      quality_metrics:
+        range: DataQualityMetric
+        multivalued: true
+        inlined_as_list: true
+        description: >-
+          Quality assessment metrics for the database
+
+  ComparisonMethodology:
+    description: >-
+      Methodology used for comparing multiple derivation protocols in a benchmarking study.
+    attributes:
+      comparison_type:
+        range: ComparisonTypeEnum
+        description: >-
+          Type of comparison (transcriptomic, proteomic, functional, etc.)
+      normalization_method:
+        description: >-
+          Method used for data normalization across protocols
+      statistical_approach:
+        description: >-
+          Statistical methods used for comparison (e.g., DESeq2, edgeR, limma)
+      similarity_metrics:
+        multivalued: true
+        description: >-
+          Metrics used to assess similarity (correlation, distance measures, etc.)
+      multiple_testing_correction:
+        description: >-
+          Method used for multiple testing correction
+      clustering_method:
+        description: >-
+          Clustering or dimensionality reduction methods used
+
+  BenchmarkingMetric:
+    description: >-
+      Specific metric used to assess the performance of derivation protocols.
+    attributes:
+      metric_name:
+        required: true
+        description: >-
+          Name of the benchmarking metric
+      metric_type:
+        range: MetricTypeEnum
+        description: >-
+          Type of metric (similarity, functional, expression, etc.)
+      metric_value:
+        range: float
+        description: >-
+          Numerical value of the metric
+      metric_range:
+        description: >-
+          Expected range or scale of the metric
+      higher_is_better:
+        range: boolean
+        description: >-
+          Whether higher values indicate better performance
+      calculation_method:
+        description: >-
+          Method used to calculate this metric
+      reference_standard:
+        description: >-
+          What this metric is being compared against
+
+  ProtocolRanking:
+    description: >-
+      Ranking of a protocol based on benchmarking results.
+    attributes:
+      protocol:
+        range: DerivationProtocol
+        inlined: true
+        required: true
+        description: >-
+          The protocol being ranked
+      overall_rank:
+        range: integer
+        description: >-
+          Overall rank among compared protocols (1 = best)
+      overall_score:
+        range: float
+        description: >-
+          Overall composite score
+      category_scores:
+        range: CategoryScore
+        multivalued: true
+        inlined_as_list: true
+        description: >-
+          Scores in specific categories (e.g., similarity, efficiency, cost)
+      strengths:
+        multivalued: true
+        description: >-
+          Identified strengths of this protocol
+      weaknesses:
+        multivalued: true
+        description: >-
+          Identified weaknesses or limitations
+      recommended_applications:
+        multivalued: true
+        description: >-
+          Recommended use cases for this protocol
+
+  CategoryScore:
+    description: >-
+      Score for a specific evaluation category in protocol benchmarking.
+    attributes:
+      category_name:
+        required: true
+        description: >-
+          Name of the evaluation category
+      score:
+        range: float
+        required: true
+        description: >-
+          Numerical score for this category
+      rank_in_category:
+        range: integer
+        description: >-
+          Rank within this specific category
+      weight:
+        range: float
+        description: >-
+          Weight of this category in overall scoring
+
+  DataQualityMetric:
+    description: >-
+      Quality assessment metric for external databases used in benchmarking.
+    attributes:
+      metric_name:
+        required: true
+        description: >-
+          Name of the quality metric
+      metric_value:
+        range: float
+        description: >-
+          Value of the quality metric
+      quality_threshold:
+        range: float
+        description: >-
+          Threshold for acceptable quality
+      passes_quality:
+        range: boolean
+        description: >-
+          Whether the data passes quality criteria
+
+  # ==========================================
   # SUPPORTING CLASSES FOR NEW TAXONOMY
   # ==========================================
 
@@ -1908,6 +2271,139 @@ enums:
         description: Time series cross-validation
       MONTE_CARLO:
         description: Monte Carlo cross-validation
+
+  # ==========================================
+  # ENUMS FOR DERIVATION PROTOCOLS AND BENCHMARKING
+  # ==========================================
+
+  ReagentRoleEnum:
+    permissible_values:
+      GROWTH_FACTOR:
+        description: Growth factor promoting cell proliferation or differentiation
+      CYTOKINE:
+        description: Cytokine signaling molecule
+      HORMONE:
+        description: Hormone regulating cellular processes
+      SMALL_MOLECULE:
+        description: Small molecule compound (drugs, supplements)
+      MATRIX_COMPONENT:
+        description: Extracellular matrix component
+      BUFFER_COMPONENT:
+        description: Buffer or media component
+      INHIBITOR:
+        description: Pathway or enzyme inhibitor
+      ACTIVATOR:
+        description: Pathway or enzyme activator
+      SUBSTRATE:
+        description: Substrate for enzymatic reactions
+      SUPPLEMENT:
+        description: Media supplement or additive
+
+  OperatorDependenceEnum:
+    permissible_values:
+      LOW:
+        description: Minimal dependence on operator skill
+      MODERATE:
+        description: Some dependence on operator experience
+      HIGH:
+        description: High dependence on operator expertise
+      CRITICAL:
+        description: Critical dependence on specialized training
+
+  EquipmentSensitivityEnum:
+    permissible_values:
+      LOW:
+        description: Works with standard laboratory equipment
+      MODERATE:
+        description: Requires some specialized equipment
+      HIGH:
+        description: Requires specialized or expensive equipment
+      CRITICAL:
+        description: Requires highly specialized or custom equipment
+
+  CostLevelEnum:
+    permissible_values:
+      LOW:
+        description: Low cost, accessible to most laboratories
+      MODERATE:
+        description: Moderate cost, may require budget planning
+      HIGH:
+        description: High cost, significant investment required
+      VERY_HIGH:
+        description: Very high cost, specialized funding needed
+
+  TimeInvestmentEnum:
+    permissible_values:
+      SHORT:
+        description: Less than 1 week total time
+      MODERATE:
+        description: 1-4 weeks total time
+      LONG:
+        description: 1-3 months total time
+      VERY_LONG:
+        description: More than 3 months total time
+
+  DatabaseTypeEnum:
+    permissible_values:
+      GENE_EXPRESSION:
+        description: Gene expression database (RNA-seq, microarray)
+        meaning: EDAM:3308
+      SINGLE_CELL_RNA_SEQ:
+        description: Single-cell RNA sequencing database
+        meaning: EDAM:3933
+      PROTEOMICS:
+        description: Proteomics database
+        meaning: EDAM:0121
+      METABOLOMICS:
+        description: Metabolomics database
+        meaning: EDAM:3172
+      EPIGENOMICS:
+        description: Epigenomics database (ChIP-seq, ATAC-seq, etc.)
+      MULTI_OMICS:
+        description: Multi-omics integrated database
+      CLINICAL:
+        description: Clinical data database
+      PHENOTYPIC:
+        description: Phenotypic characterization database
+
+  ComparisonTypeEnum:
+    permissible_values:
+      TRANSCRIPTOMIC:
+        description: Gene expression comparison
+        meaning: EDAM:3308
+      PROTEOMIC:
+        description: Protein expression comparison
+        meaning: EDAM:0121
+      METABOLOMIC:
+        description: Metabolite comparison
+        meaning: EDAM:3172
+      FUNCTIONAL:
+        description: Functional assay comparison
+      MORPHOLOGICAL:
+        description: Morphological feature comparison
+      MULTI_OMICS:
+        description: Multiple omics data comparison
+      COMPUTATIONAL:
+        description: Computational model comparison
+
+  MetricTypeEnum:
+    permissible_values:
+      SIMILARITY:
+        description: Similarity metric to reference data
+      FUNCTIONAL:
+        description: Functional capability metric
+      EXPRESSION:
+        description: Gene/protein expression metric
+      EFFICIENCY:
+        description: Protocol efficiency metric
+      REPRODUCIBILITY:
+        description: Reproducibility metric
+      COST_EFFECTIVENESS:
+        description: Cost-effectiveness metric
+      TIME_EFFICIENCY:
+        description: Time efficiency metric
+      QUALITY:
+        description: Overall quality metric
 
 
 

--- a/tests/data/valid/ProtocolBenchmarkingStudy-macrophage-001.yaml
+++ b/tests/data/valid/ProtocolBenchmarkingStudy-macrophage-001.yaml
@@ -94,12 +94,6 @@ protocols_compared:
       equipment_sensitivity: "LOW"
       cost_assessment: "MODERATE"
       time_investment: "MODERATE"
-    original_publication:
-      id: "PMID:12345678"
-      title: "Standardized protocols for M-CSF macrophage differentiation"
-      authors: ["Murray PJ", "Allen JE", "Biswas SK"]
-      journal: "Immunity"
-      year: 2014
 
   - id: "protocol:gmcsf-001"
     name: "GM-CSF Alternative Activation Protocol"

--- a/tests/data/valid/ProtocolBenchmarkingStudy-macrophage-001.yaml
+++ b/tests/data/valid/ProtocolBenchmarkingStudy-macrophage-001.yaml
@@ -1,0 +1,297 @@
+id: "benchmarking:001"
+name: "Transcriptomic Benchmarking of Monocyte-Derived Macrophage Polarization Protocols"
+description: >-
+  A comprehensive transcriptomic study comparing multiple in vitro polarization 
+  methods for deriving macrophages from human monocytes. This study leverages 
+  an unbiased RNA-seq database to characterize gene expression profiles across 
+  commonly employed polarization protocols and assess their physiological relevance
+  compared to primary tissue macrophages.
+type: "ProtocolBenchmarkingStudy"
+
+context_of_use: >-
+  Protocol optimization for macrophage-based disease modeling, drug screening, 
+  and immunological research. Supports selection of optimal derivation methods 
+  for specific research applications.
+
+biological_context: >-
+  Human monocyte-to-macrophage differentiation and polarization represents a 
+  critical cellular transition in immune system function. Multiple in vitro 
+  protocols exist with varying degrees of physiological relevance.
+
+perturbations: >-
+  Different polarization cocktails including M-CSF, GM-CSF, IL-4, IL-13, 
+  LPS, IFN-γ, and various combinations applied over 5-7 day protocols.
+
+endpoints: >-
+  Bulk RNA-seq transcriptomic profiling, surface marker expression analysis,
+  functional cytokine secretion assays, and phagocytosis capacity measurements.
+
+plan_comparators: >-
+  Primary alveolar macrophages, tissue-resident macrophages from multiple organs,
+  and publicly available macrophage expression databases.
+
+protocols_compared:
+  - id: "protocol:mcsf-001"
+    name: "M-CSF Classical Activation Protocol"
+    description: >-
+      Standard M-CSF-driven monocyte differentiation followed by LPS/IFN-γ 
+      classical activation (M1-like polarization).
+    starting_cell_type:
+      id: "CL:0000576"
+      name: "monocyte"
+    target_cell_type:
+      id: "CL:0000235"
+      name: "macrophage"
+    duration_days: 7
+    efficiency_percentage: 85.2
+    protocol_steps:
+      - step_number: 1
+        step_name: "Monocyte isolation and seeding"
+        duration_hours: 4
+        reagents:
+          - reagent_name: "M-CSF"
+            concentration: "50 ng/ml"
+            reagent_role: "GROWTH_FACTOR"
+            supplier: "R&D Systems 216-MC"
+        culture_conditions: "RPMI-1640 + 10% FBS, 37°C, 5% CO2"
+        critical_parameters:
+          - "Monocyte purity >95%"
+          - "Seeding density 1x10^6 cells/ml"
+      - step_number: 2
+        step_name: "Differentiation phase"
+        duration_hours: 120
+        reagents:
+          - reagent_name: "M-CSF"
+            concentration: "50 ng/ml"
+            reagent_role: "GROWTH_FACTOR"
+        culture_conditions: "Media replacement every 48h"
+        critical_parameters:
+          - "Maintain M-CSF concentration"
+          - "Monitor cell adhesion"
+      - step_number: 3
+        step_name: "Classical activation"
+        duration_hours: 24
+        reagents:
+          - reagent_name: "LPS"
+            concentration: "100 ng/ml"
+            reagent_role: "ACTIVATOR"
+            supplier: "Sigma L4391"
+          - reagent_name: "IFN-γ"
+            concentration: "20 ng/ml"
+            reagent_role: "CYTOKINE"
+            supplier: "Peprotech 300-02"
+        critical_parameters:
+          - "Simultaneous addition of LPS and IFN-γ"
+          - "Incubation for exactly 24h"
+    success_criteria:
+      - "CD68+ CD163+ double positive cells >80%"
+      - "TNF-α secretion >500 pg/ml upon LPS stimulation"
+      - "Adherent macrophage morphology"
+    reproducibility_assessment:
+      inter_laboratory_variability: 0.15
+      batch_to_batch_consistency: 0.89
+      operator_dependence: "MODERATE"
+      equipment_sensitivity: "LOW"
+      cost_assessment: "MODERATE"
+      time_investment: "MODERATE"
+    original_publication:
+      id: "PMID:12345678"
+      title: "Standardized protocols for M-CSF macrophage differentiation"
+      authors: ["Murray PJ", "Allen JE", "Biswas SK"]
+      journal: "Immunity"
+      year: 2014
+
+  - id: "protocol:gmcsf-001"
+    name: "GM-CSF Alternative Activation Protocol"
+    description: >-
+      GM-CSF-driven monocyte differentiation followed by IL-4/IL-13 alternative 
+      activation (M2-like polarization).
+    starting_cell_type:
+      id: "CL:0000576"
+      name: "monocyte"
+    target_cell_type:
+      id: "CL:0000235"
+      name: "macrophage"
+    duration_days: 6
+    efficiency_percentage: 78.9
+    protocol_steps:
+      - step_number: 1
+        step_name: "Monocyte isolation and GM-CSF priming"
+        duration_hours: 4
+        reagents:
+          - reagent_name: "GM-CSF"
+            concentration: "100 ng/ml"
+            reagent_role: "GROWTH_FACTOR"
+            supplier: "Peprotech 300-03"
+        culture_conditions: "RPMI-1640 + 10% FBS, 37°C, 5% CO2"
+      - step_number: 2
+        step_name: "Differentiation with GM-CSF"
+        duration_hours: 96
+        reagents:
+          - reagent_name: "GM-CSF"
+            concentration: "100 ng/ml"
+            reagent_role: "GROWTH_FACTOR"
+        culture_conditions: "Media replacement every 48h"
+      - step_number: 3
+        step_name: "Alternative activation"
+        duration_hours: 48
+        reagents:
+          - reagent_name: "IL-4"
+            concentration: "20 ng/ml"
+            reagent_role: "CYTOKINE"
+            supplier: "R&D Systems 204-IL"
+          - reagent_name: "IL-13"
+            concentration: "20 ng/ml"
+            reagent_role: "CYTOKINE"
+            supplier: "R&D Systems 213-IL"
+    success_criteria:
+      - "CD206+ Arg1+ double positive cells >70%"
+      - "IL-10 secretion >200 pg/ml"
+      - "Reduced TNF-α response to LPS"
+    reproducibility_assessment:
+      inter_laboratory_variability: 0.22
+      batch_to_batch_consistency: 0.83
+      operator_dependence: "MODERATE"
+      equipment_sensitivity: "LOW"
+      cost_assessment: "HIGH"
+      time_investment: "MODERATE"
+
+reference_datasets:
+  - id: "database:001"
+    name: "Human Tissue Macrophage Atlas"
+    description: >-
+      Comprehensive RNA-seq database of primary tissue-resident macrophages 
+      from multiple human organs including lung, liver, intestine, and brain.
+    database_type: "GENE_EXPRESSION"
+    data_source: "Primary human tissue samples from organ donors"
+    sample_size: 247
+    species:
+      id: "NCBITaxon:9606"
+      name: "Homo sapiens"
+    tissue_types:
+      - id: "UBERON:0002048"
+        name: "lung"
+      - id: "UBERON:0002107"
+        name: "liver"
+      - id: "UBERON:0000160"
+        name: "intestine"
+      - id: "UBERON:0000955"
+        name: "brain"
+    access_url: "https://www.immunologydb.org/tissue_macrophages"
+    data_processing: "DESeq2 normalization, batch correction with ComBat-seq"
+    quality_metrics:
+      - metric_name: "RNA integrity number"
+        metric_value: 8.2
+        quality_threshold: 7.0
+        passes_quality: true
+      - metric_name: "Mapping rate"
+        metric_value: 89.5
+        quality_threshold: 80.0
+        passes_quality: true
+
+comparison_methodology:
+  comparison_type: "TRANSCRIPTOMIC"
+  normalization_method: "DESeq2 variance stabilizing transformation"
+  statistical_approach: "limma-voom with empirical Bayes moderation"
+  similarity_metrics:
+    - "Pearson correlation coefficient"
+    - "Spearman rank correlation"
+    - "Principal component analysis distance"
+  multiple_testing_correction: "Benjamini-Hochberg FDR correction"
+  clustering_method: "Hierarchical clustering with Ward linkage"
+
+benchmarking_metrics:
+  - metric_name: "Transcriptomic Similarity to Primary Macrophages"
+    metric_type: "SIMILARITY"
+    metric_value: 0.73
+    metric_range: "0.0-1.0 (correlation coefficient)"
+    higher_is_better: true
+    calculation_method: "Pearson correlation with tissue macrophage signatures"
+    reference_standard: "Primary alveolar macrophages"
+
+  - metric_name: "Pathway Conservation Score"
+    metric_type: "FUNCTIONAL"
+    metric_value: 0.68
+    metric_range: "0.0-1.0 (GSEA enrichment)"
+    higher_is_better: true
+    calculation_method: "GSEA with hallmark gene sets"
+    reference_standard: "Canonical immune pathway signatures"
+
+  - metric_name: "Protocol Efficiency"
+    metric_type: "EFFICIENCY"
+    metric_value: 82.1
+    metric_range: "0-100 (percentage successful differentiation)"
+    higher_is_better: true
+    calculation_method: "Flow cytometry analysis of differentiation markers"
+    reference_standard: "Industry standard protocols"
+
+protocol_ranking:
+  - protocol:
+      id: "protocol:mcsf-001"
+      name: "M-CSF Classical Activation Protocol"
+    overall_rank: 1
+    overall_score: 8.2
+    category_scores:
+      - category_name: "Transcriptomic Similarity"
+        score: 8.5
+        rank_in_category: 1
+        weight: 0.4
+      - category_name: "Functional Relevance"
+        score: 7.8
+        rank_in_category: 1
+        weight: 0.3
+      - category_name: "Reproducibility"
+        score: 8.9
+        rank_in_category: 1
+        weight: 0.2
+      - category_name: "Cost-Effectiveness"
+        score: 7.2
+        rank_in_category: 2
+        weight: 0.1
+    strengths:
+      - "High transcriptomic similarity to primary M1 macrophages"
+      - "Excellent reproducibility across laboratories"
+      - "Well-established and standardized protocol"
+      - "Strong inflammatory response profile"
+    weaknesses:
+      - "Limited plasticity in activation states"
+      - "May not fully recapitulate tissue-specific signatures"
+    recommended_applications:
+      - "Pro-inflammatory disease modeling"
+      - "Anti-inflammatory drug screening"
+      - "Classical activation studies"
+
+  - protocol:
+      id: "protocol:gmcsf-001"
+      name: "GM-CSF Alternative Activation Protocol"
+    overall_rank: 2
+    overall_score: 7.1
+    category_scores:
+      - category_name: "Transcriptomic Similarity"
+        score: 6.8
+        rank_in_category: 2
+        weight: 0.4
+      - category_name: "Functional Relevance"
+        score: 7.2
+        rank_in_category: 2
+        weight: 0.3
+      - category_name: "Reproducibility"
+        score: 6.5
+        rank_in_category: 2
+        weight: 0.2
+      - category_name: "Cost-Effectiveness"
+        score: 8.5
+        rank_in_category: 1
+        weight: 0.1
+    strengths:
+      - "Good alternative activation profile"
+      - "Suitable for anti-inflammatory studies"
+      - "Reasonable cost-effectiveness"
+    weaknesses:
+      - "Higher variability between experiments"
+      - "Less similarity to primary tissue macrophages"
+      - "Moderate efficiency compared to M-CSF protocols"
+    recommended_applications:
+      - "Alternative activation studies"
+      - "Wound healing models"
+      - "Resolution of inflammation research"


### PR DESCRIPTION
This PR adds comprehensive schema support for modeling transcriptomic benchmarking studies of NAM derivation protocols, exemplified by monocyte-derived macrophage polarization protocol comparisons.

## New Schema Classes:
- DerivationProtocol: Detailed protocol specifications with steps and reagents
- ProtocolBenchmarkingStudy: Study type for systematic protocol comparisons
- ExternalDatabase: Reference databases for benchmarking comparisons
- ComparisonMethodology: Statistical and computational comparison methods
- BenchmarkingMetric & ProtocolRanking: Performance assessment and ranking

## Example Data:
Added comprehensive YAML example modeling transcriptomic benchmarking of M-CSF vs GM-CSF macrophage polarization protocols.

Addresses #8

Generated with [Claude Code](https://claude.ai/code)